### PR TITLE
Hide Discord webhook URL from config API

### DIFF
--- a/app/src/components/SettingsPanel.tsx
+++ b/app/src/components/SettingsPanel.tsx
@@ -145,7 +145,9 @@ export function SettingsPanel() {
           <dl className="mt-2 grid gap-2 sm:grid-cols-2">
             <div>
               <dt className="font-medium text-slate-500 dark:text-slate-400">Discord 웹훅 (기본)</dt>
-              <dd className="break-all text-slate-700 dark:text-slate-200">{serverConfig.discordWebhookUrl ?? '설정되지 않음'}</dd>
+              <dd className="text-slate-700 dark:text-slate-200">
+                {serverConfig.hasDiscordWebhook ? '설정됨' : '없음'}
+              </dd>
             </div>
             <div>
               <dt className="font-medium text-slate-500 dark:text-slate-400">API 키</dt>

--- a/server/src/routes/config.ts
+++ b/server/src/routes/config.ts
@@ -5,7 +5,7 @@ const router = Router()
 
 router.get('/', (_req, res) => {
   const config: ServerConfig = {
-    discordWebhookUrl: process.env.DISCORD_WEBHOOK_URL ?? null,
+    hasDiscordWebhook: Boolean(process.env.DISCORD_WEBHOOK_URL),
     port: Number.parseInt(process.env.PORT ?? '8080', 10),
     timezone: process.env.TZ ?? 'Asia/Seoul',
     apiKey: process.env.API_KEY ?? null,

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -25,7 +25,7 @@ export interface Run {
 }
 
 export interface ServerConfig {
-  discordWebhookUrl: string | null
+  hasDiscordWebhook: boolean
   port: number
   timezone: string
   apiKey: string | null


### PR DESCRIPTION
## Summary
- replace the exposed Discord webhook URL with a hasDiscordWebhook flag in the config endpoint
- update shared ServerConfig type and settings panel UI to consume the new flag

## Testing
- npm run build (server)
- npm run build (app)


------
https://chatgpt.com/codex/tasks/task_e_68c90c5ebc9c8330b58a70c66e615ff8